### PR TITLE
Fix escaping " and '

### DIFF
--- a/sync_addon_metadata_translations/__main__.py
+++ b/sync_addon_metadata_translations/__main__.py
@@ -780,8 +780,8 @@ def escape_characters(source, dest='po'):
         return [
             (
                 lang_code,
-                string.replace(r'\"', r'&quot;')
-                    .replace(r'\'', r'&apos;')
+                string.replace(r'"', r'&quot;')
+                    .replace(r"'", r'&apos;')
                     .replace(r'<', r'&lt;')
                     .replace(r'>', r'&gt;')
                     .replace(r'&', r'&amp;'),


### PR DESCRIPTION
## Description

This PR fixes the wrong use of \ in raw strings that was part of https://github.com/xbmc/sync_addon_metadata_translations/pull/15.

## How has this been tested?

Like last PR, I'll test with game add-ons after merge and follow up with any changes.